### PR TITLE
Реализована логика подсчета количества запусков приложения.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,10 @@ dependencies {
 
     testImplementation Koin.koinTest
     testImplementation Tests.junit
+    testImplementation Tests.mockito
+    testImplementation Tests.mockitoKotlin
+    testImplementation Tests.mockitoInline
+    testImplementation Tests.googleTruth
     androidTestImplementation Tests.extJunit
     androidTestImplementation Tests.espresso
 }

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/app/AndroidCleanArchitecture.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/app/AndroidCleanArchitecture.kt
@@ -1,0 +1,30 @@
+package com.volokhinaleksey.androidcleanarchitecture.app
+
+import android.app.Application
+import com.volokhinaleksey.androidcleanarchitecture.di.dataSourcesModule
+import com.volokhinaleksey.androidcleanarchitecture.di.interactorsModule
+import com.volokhinaleksey.androidcleanarchitecture.di.mainScreenModule
+import com.volokhinaleksey.androidcleanarchitecture.di.managersModule
+import com.volokhinaleksey.androidcleanarchitecture.di.repositoriesModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+
+class AndroidCleanArchitecture : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@AndroidCleanArchitecture)
+            modules(
+                listOf(
+                    managersModule,
+                    dataSourcesModule,
+                    repositoriesModule,
+                    interactorsModule,
+                    mainScreenModule,
+                )
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchCounterDataSourceImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchCounterDataSourceImpl.kt
@@ -9,9 +9,18 @@ class LaunchCounterDataSourceImpl(
     private val storageManager: StorageManager
 ) : LaunchCounterDataSource {
 
+    /**
+     * A method for saving the number of app launches to the device's local storage.
+     * @param value - Object to save with the number of app launches
+     */
+
     override fun saveLaunchCount(value: DataLaunchCount) {
         storageManager.saveLong(key = LAUNCH_COUNT, value = value.launchCount)
     }
+
+    /**
+     * A method for getting the number of app launches of their local device storage.
+     */
 
     override fun getLaunchCount(): DataLaunchCount {
         return DataLaunchCount(

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchCounterDataSourceImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchCounterDataSourceImpl.kt
@@ -1,0 +1,25 @@
+package com.volokhinaleksey.androidcleanarchitecture.datasource
+
+import com.volokhinaleksey.androidcleanarchitecture.managers.StorageManager
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+import com.volokhinaleksey.androidcleanarchitecture.util.DEFAULT_LAUNCH_COUNT
+import com.volokhinaleksey.androidcleanarchitecture.util.LAUNCH_COUNT
+
+class LaunchCounterDataSourceImpl(
+    private val storageManager: StorageManager
+) : LaunchCounterDataSource {
+
+    override fun saveLaunchCount(value: DataLaunchCount) {
+        storageManager.saveLong(key = LAUNCH_COUNT, value = value.launchCount)
+    }
+
+    override fun getLaunchCount(): DataLaunchCount {
+        return DataLaunchCount(
+            launchCount = storageManager.getLong(
+                key = LAUNCH_COUNT,
+                defaultValue = DEFAULT_LAUNCH_COUNT
+            )
+        )
+    }
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchСounterDataSource.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchСounterDataSource.kt
@@ -1,0 +1,11 @@
+package com.volokhinaleksey.androidcleanarchitecture.datasource
+
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+
+interface LaunchCounterDataSource {
+
+    fun saveLaunchCount(value: DataLaunchCount)
+
+    fun getLaunchCount(): DataLaunchCount
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchСounterDataSource.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/datasource/LaunchСounterDataSource.kt
@@ -4,7 +4,16 @@ import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
 
 interface LaunchCounterDataSource {
 
+    /**
+     * Method for saving the number of app launches
+     * @param value - An object to save with the number of app launches.
+     */
+
     fun saveLaunchCount(value: DataLaunchCount)
+
+    /**
+     * Method for getting the number of app launches.
+     */
 
     fun getLaunchCount(): DataLaunchCount
 

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/di/KoinModules.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/di/KoinModules.kt
@@ -1,0 +1,42 @@
+package com.volokhinaleksey.androidcleanarchitecture.di
+
+import android.content.SharedPreferences
+import com.volokhinaleksey.androidcleanarchitecture.datasource.LaunchCounterDataSource
+import com.volokhinaleksey.androidcleanarchitecture.datasource.LaunchCounterDataSourceImpl
+import com.volokhinaleksey.androidcleanarchitecture.interactors.LaunchCounterInteractor
+import com.volokhinaleksey.androidcleanarchitecture.interactors.LaunchCounterInteractorImpl
+import com.volokhinaleksey.androidcleanarchitecture.managers.StorageManager
+import com.volokhinaleksey.androidcleanarchitecture.managers.StorageManagerImpl
+import com.volokhinaleksey.androidcleanarchitecture.repositories.LaunchCounterRepository
+import com.volokhinaleksey.androidcleanarchitecture.repositories.LaunchCounterRepositoryImpl
+import com.volokhinaleksey.androidcleanarchitecture.util.CLEAN_ARCHITECTURE_APP
+import com.volokhinaleksey.androidcleanarchitecture.viewmodels.MainViewModel
+import org.koin.android.ext.koin.androidApplication
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val managersModule = module {
+    single<SharedPreferences> {
+        androidApplication().getSharedPreferences(
+            CLEAN_ARCHITECTURE_APP,
+            android.content.Context.MODE_PRIVATE
+        )
+    }
+    single<StorageManager> { StorageManagerImpl(get()) }
+}
+
+val dataSourcesModule = module {
+    single<LaunchCounterDataSource> { LaunchCounterDataSourceImpl(get()) }
+}
+
+val repositoriesModule = module {
+    single<LaunchCounterRepository> { LaunchCounterRepositoryImpl(get()) }
+}
+
+val interactorsModule = module {
+    single<LaunchCounterInteractor> { LaunchCounterInteractorImpl(get()) }
+}
+
+val mainScreenModule = module {
+    viewModel { MainViewModel(get()) }
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractor.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractor.kt
@@ -1,0 +1,12 @@
+package com.volokhinaleksey.androidcleanarchitecture.interactors
+
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+
+interface LaunchCounterInteractor {
+
+    fun saveLaunchCount(dataLaunchCount: DataLaunchCount)
+
+    fun getLaunchCount(): DataLaunchCount
+
+    fun isShowEvaluationWindow(value: Long): Boolean
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractor.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractor.kt
@@ -4,9 +4,23 @@ import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
 
 interface LaunchCounterInteractor {
 
+    /**
+     * A method for saving the number of launches.
+     * @param dataLaunchCount - The object is the number of runs to save.
+     */
+
     fun saveLaunchCount(dataLaunchCount: DataLaunchCount)
+
+    /**
+     * Method for getting the number of launches.
+     */
 
     fun getLaunchCount(): DataLaunchCount
 
-    fun isShowEvaluationWindow(value: Long): Boolean
+    /**
+     * A method that returns whether the application evaluation window should be shown or not based on the number of launches.
+     * @param launchCount - Number of app launches
+     */
+
+    fun isShowEvaluationWindow(launchCount: Long): Boolean
 }

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractorImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractorImpl.kt
@@ -7,14 +7,29 @@ class LaunchCounterInteractorImpl(
     private val repository: LaunchCounterRepository
 ) : LaunchCounterInteractor {
 
+    /**
+     * A method for saving the number of runs from the repository.
+     * @param dataLaunchCount - The object is the number of runs to save.
+     */
+
     override fun saveLaunchCount(dataLaunchCount: DataLaunchCount) {
-        repository.saveLaunchCount(value = dataLaunchCount)
+        repository.saveLaunchCount(launchCount = dataLaunchCount)
     }
+
+    /**
+     * Method for getting the number of runs from the repository.
+     */
 
     override fun getLaunchCount(): DataLaunchCount = repository.getLaunchCount()
 
-    override fun isShowEvaluationWindow(value: Long): Boolean {
-        return value == 2L || (value - 2L) % 4L == 0L
+    /**
+     * A method that returns whether the application evaluation window should be displayed or not, depending on the number of launches.
+     * If the value is 2, or every 4 starts after 2. i.e. show a window for 2, 6, 10, 14, etc. launches.
+     * @param launchCount - Number of application launches
+     */
+
+    override fun isShowEvaluationWindow(launchCount: Long): Boolean {
+        return launchCount == 2L || (launchCount - 2L) % 4L == 0L
     }
 
 }

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractorImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/interactors/LaunchCounterInteractorImpl.kt
@@ -1,0 +1,20 @@
+package com.volokhinaleksey.androidcleanarchitecture.interactors
+
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+import com.volokhinaleksey.androidcleanarchitecture.repositories.LaunchCounterRepository
+
+class LaunchCounterInteractorImpl(
+    private val repository: LaunchCounterRepository
+) : LaunchCounterInteractor {
+
+    override fun saveLaunchCount(dataLaunchCount: DataLaunchCount) {
+        repository.saveLaunchCount(value = dataLaunchCount)
+    }
+
+    override fun getLaunchCount(): DataLaunchCount = repository.getLaunchCount()
+
+    override fun isShowEvaluationWindow(value: Long): Boolean {
+        return value == 2L || (value - 2L) % 4L == 0L
+    }
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManager.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManager.kt
@@ -2,7 +2,19 @@ package com.volokhinaleksey.androidcleanarchitecture.managers
 
 interface StorageManager {
 
+    /**
+     * A method for storing numeric values.
+     * @param key - The key to save.
+     * @param value - The value to save.
+     */
+
     fun saveLong(key: String, value: Long)
+
+    /**
+     * A method for getting a numeric value.
+     * @param key - The key for getting a numeric value.
+     * @param defaultValue - Standard numeric value.
+     */
 
     fun getLong(key: String, defaultValue: Long): Long
 

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManager.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManager.kt
@@ -1,0 +1,9 @@
+package com.volokhinaleksey.androidcleanarchitecture.managers
+
+interface StorageManager {
+
+    fun saveLong(key: String, value: Long)
+
+    fun getLong(key: String, defaultValue: Long): Long
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManagerImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManagerImpl.kt
@@ -6,12 +6,24 @@ class StorageManagerImpl(
     private val sharedPreferences: SharedPreferences
 ) : StorageManager {
 
+    /**
+     * Method for saving numeric values to the device's local storage.
+     * @param key - Key to save.
+     * @param value - Value for saving.
+     */
+
     override fun saveLong(key: String, value: Long) {
         sharedPreferences
             .edit()
             .putLong(key, value)
             .apply()
     }
+
+    /**
+     * Method for getting a numeric value from the device's local storage.
+     * @param key - The key for getting a numeric value.
+     * @param defaultValue - Standard numeric value.
+     */
 
     override fun getLong(key: String, defaultValue: Long): Long {
         return sharedPreferences.getLong(key, defaultValue)

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManagerImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/managers/StorageManagerImpl.kt
@@ -1,0 +1,20 @@
+package com.volokhinaleksey.androidcleanarchitecture.managers
+
+import android.content.SharedPreferences
+
+class StorageManagerImpl(
+    private val sharedPreferences: SharedPreferences
+) : StorageManager {
+
+    override fun saveLong(key: String, value: Long) {
+        sharedPreferences
+            .edit()
+            .putLong(key, value)
+            .apply()
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long {
+        return sharedPreferences.getLong(key, defaultValue)
+    }
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/models/DataLaunchCount.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/models/DataLaunchCount.kt
@@ -1,0 +1,5 @@
+package com.volokhinaleksey.androidcleanarchitecture.models
+
+data class DataLaunchCount(
+    var launchCount: Long
+)

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/models/DataLaunchCount.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/models/DataLaunchCount.kt
@@ -1,5 +1,10 @@
 package com.volokhinaleksey.androidcleanarchitecture.models
 
+/**
+ * An object for storing the number of launches.
+ * @param launchCount - The number of app launches.
+ */
+
 data class DataLaunchCount(
     var launchCount: Long
 )

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepository.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepository.kt
@@ -4,7 +4,16 @@ import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
 
 interface LaunchCounterRepository {
 
-    fun saveLaunchCount(value: DataLaunchCount)
+    /**
+     * A method for saving the number of runs to the data source.
+     * @param launchCount - Number of app launches to save
+     */
+
+    fun saveLaunchCount(launchCount: DataLaunchCount)
+
+    /**
+     * A method for getting the number of runs from a data source.
+     */
 
     fun getLaunchCount(): DataLaunchCount
 

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepository.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepository.kt
@@ -1,0 +1,11 @@
+package com.volokhinaleksey.androidcleanarchitecture.repositories
+
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+
+interface LaunchCounterRepository {
+
+    fun saveLaunchCount(value: DataLaunchCount)
+
+    fun getLaunchCount(): DataLaunchCount
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepositoryImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepositoryImpl.kt
@@ -7,9 +7,18 @@ class LaunchCounterRepositoryImpl(
     private val launchCounterDataSource: LaunchCounterDataSource
 ) : LaunchCounterRepository {
 
-    override fun saveLaunchCount(value: DataLaunchCount) {
-        launchCounterDataSource.saveLaunchCount(value = value)
+    /**
+     * Method for saving the number of runs to the data source
+     * @param launchCount - Number of app launches to save
+     */
+
+    override fun saveLaunchCount(launchCount: DataLaunchCount) {
+        launchCounterDataSource.saveLaunchCount(value = launchCount)
     }
+
+    /**
+     * A method for getting the number of runs from a data source.
+     */
 
     override fun getLaunchCount(): DataLaunchCount = launchCounterDataSource.getLaunchCount()
 

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepositoryImpl.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/repositories/LaunchCounterRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.volokhinaleksey.androidcleanarchitecture.repositories
+
+import com.volokhinaleksey.androidcleanarchitecture.datasource.LaunchCounterDataSource
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+
+class LaunchCounterRepositoryImpl(
+    private val launchCounterDataSource: LaunchCounterDataSource
+) : LaunchCounterRepository {
+
+    override fun saveLaunchCount(value: DataLaunchCount) {
+        launchCounterDataSource.saveLaunchCount(value = value)
+    }
+
+    override fun getLaunchCount(): DataLaunchCount = launchCounterDataSource.getLaunchCount()
+
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/util/Constants.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/util/Constants.kt
@@ -1,0 +1,7 @@
+package com.volokhinaleksey.androidcleanarchitecture.util
+
+// Shared Preferences keys
+
+const val LAUNCH_COUNT = "launch_count"
+const val DEFAULT_LAUNCH_COUNT = 0L
+const val CLEAN_ARCHITECTURE_APP = "clean_architecture_app"

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/MainViewModel.kt
@@ -23,6 +23,6 @@ class MainViewModel(
 
     fun isShowingEvaluationWindow(count: Long) {
         _isShowingEvaluationWindow.value =
-            launchCounterInteractor.isShowEvaluationWindow(value = count)
+            launchCounterInteractor.isShowEvaluationWindow(launchCount = count)
     }
 }

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/MainViewModel.kt
@@ -1,0 +1,28 @@
+package com.volokhinaleksey.androidcleanarchitecture.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.volokhinaleksey.androidcleanarchitecture.interactors.LaunchCounterInteractor
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+import com.volokhinaleksey.androidcleanarchitecture.viewmodels.base.BaseViewModel
+
+class MainViewModel(
+    private val launchCounterInteractor: LaunchCounterInteractor
+) : BaseViewModel<DataLaunchCount>() {
+
+    private val _isShowingEvaluationWindow: MutableLiveData<Boolean> = MutableLiveData()
+    val isShowingEvaluationWindow: LiveData<Boolean> get() = _isShowingEvaluationWindow
+
+    fun saveLaunchCount(count: DataLaunchCount) {
+        launchCounterInteractor.saveLaunchCount(dataLaunchCount = count)
+    }
+
+    fun getLaunchCount() {
+        mutableData.value = launchCounterInteractor.getLaunchCount()
+    }
+
+    fun isShowingEvaluationWindow(count: Long) {
+        _isShowingEvaluationWindow.value =
+            launchCounterInteractor.isShowEvaluationWindow(value = count)
+    }
+}

--- a/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/base/BaseViewModel.kt
+++ b/app/src/main/java/com/volokhinaleksey/androidcleanarchitecture/viewmodels/base/BaseViewModel.kt
@@ -1,0 +1,12 @@
+package com.volokhinaleksey.androidcleanarchitecture.viewmodels.base
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+abstract class BaseViewModel<T> : ViewModel() {
+
+    protected val mutableData: MutableLiveData<T> = MutableLiveData()
+    val data: LiveData<T> get() = mutableData
+
+}

--- a/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/ExampleUnitTest.kt
+++ b/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package com.volokhinaleksey.androidcleanarchitecture
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/TestingLaunchCounter.kt
+++ b/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/TestingLaunchCounter.kt
@@ -31,7 +31,7 @@ class TestingLaunchCounter {
     @Test
     fun `checking the correct saving of startup data`() {
         val dataForSave = mock<DataLaunchCount>()
-        doNothing().`when`(launchCounterRepository).saveLaunchCount(value = dataForSave)
+        doNothing().`when`(launchCounterRepository).saveLaunchCount(launchCount = dataForSave)
         launchCounterInteractor.saveLaunchCount(dataLaunchCount = dataForSave)
         verify(launchCounterRepository, atLeastOnce()).saveLaunchCount(dataForSave)
     }

--- a/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/TestingLaunchCounter.kt
+++ b/app/src/test/java/com/volokhinaleksey/androidcleanarchitecture/TestingLaunchCounter.kt
@@ -1,0 +1,67 @@
+package com.volokhinaleksey.androidcleanarchitecture
+
+import com.google.common.truth.Truth.assertThat
+import com.volokhinaleksey.androidcleanarchitecture.interactors.LaunchCounterInteractor
+import com.volokhinaleksey.androidcleanarchitecture.interactors.LaunchCounterInteractorImpl
+import com.volokhinaleksey.androidcleanarchitecture.models.DataLaunchCount
+import com.volokhinaleksey.androidcleanarchitecture.repositories.LaunchCounterRepository
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.verify
+
+class TestingLaunchCounter {
+
+    private lateinit var launchCounterInteractor: LaunchCounterInteractor
+
+    @Mock
+    private lateinit var launchCounterRepository: LaunchCounterRepository
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        launchCounterInteractor = LaunchCounterInteractorImpl(repository = launchCounterRepository)
+    }
+
+    @Test
+    fun `checking the correct saving of startup data`() {
+        val dataForSave = mock<DataLaunchCount>()
+        doNothing().`when`(launchCounterRepository).saveLaunchCount(value = dataForSave)
+        launchCounterInteractor.saveLaunchCount(dataLaunchCount = dataForSave)
+        verify(launchCounterRepository, atLeastOnce()).saveLaunchCount(dataForSave)
+    }
+
+    @Test
+    fun `checking the receipt of data on the number of app launches`() {
+        `when`(launchCounterRepository.getLaunchCount()).thenReturn(DataLaunchCount(1))
+        val result = launchCounterInteractor.getLaunchCount()
+        assertThat(result.launchCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `checking the display of the evaluation window for the 2nd launch return true`() {
+        val launchCount = 2L
+        val result = launchCounterInteractor.isShowEvaluationWindow(launchCount)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `checking the evaluation window display for every 4 launches return true`() {
+        val launchCount = 6L
+        val result = launchCounterInteractor.isShowEvaluationWindow(launchCount)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `checking the display of the evaluation window for the 3rd launch return false`() {
+        val launchCount = 3L
+        val result = launchCounterInteractor.isShowEvaluationWindow(launchCount)
+        assertThat(result).isFalse()
+    }
+
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -41,6 +41,10 @@ object Versions {
     const val junit = "4.13.2"
     const val extJunit = "1.1.5"
     const val espresso = "3.5.1"
+    const val googleTruth = "1.1.3"
+    const val mockito = "5.2.0"
+    const val mockitoInline = "5.2.0"
+    const val kotlinMockito = "4.1.0"
 }
 
 object Android {
@@ -67,6 +71,10 @@ object Tests {
     const val junit = "junit:junit:${Versions.junit}"
     const val espresso = "androidx.test.espresso:espresso-core:${Versions.espresso}"
     const val extJunit = "androidx.test.ext:junit:${Versions.extJunit}"
+    const val googleTruth = "com.google.truth:truth:${Versions.googleTruth}"
+    const val mockito = "org.mockito:mockito-core:${Versions.mockito}"
+    const val mockitoInline = "org.mockito:mockito-inline:${Versions.mockitoInline}"
+    const val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:${Versions.kotlinMockito}"
 }
 
 object Koin {


### PR DESCRIPTION
Согласно принципам чистой архитектуры реализована логика подсчета запусков, а также логика отображения для отображения окна оценки в будущем, на 2 запуск приложения и далее на каждый 4. 
Т.е в будущем окно оценки приложения должно показываться на 2, 6, 10 и т.д запуски.
Написаны unit-тесты для тестирования сохранения/получения и правильной работы логики отображения.